### PR TITLE
fix: patch createPlace and updatePlace service bugs

### DIFF
--- a/src/controllers/places.controller.ts
+++ b/src/controllers/places.controller.ts
@@ -58,10 +58,7 @@ class PlacesController {
       const data = req.body;
       const userId = req.user.id;
       const fileBuffer = req.file?.buffer;
-      const newPlace = await createPlace(
-        { ...data, creatorId: userId },
-        fileBuffer,
-      );
+      const newPlace = await createPlace(userId, { ...data }, fileBuffer);
       res.status(201).json({
         success: true,
         message: "Place created successfully",

--- a/src/repositories/places.repository.ts
+++ b/src/repositories/places.repository.ts
@@ -27,9 +27,11 @@ class PlacesRepository {
     }
   }
 
-  async create(data: Prisma.PlaceCreateInput) {
+  async create(data: Omit<Prisma.PlaceCreateInput, "creator">, userId: string) {
     try {
-      return await prisma.place.create({ data });
+      return await prisma.place.create({
+        data: { ...data, creator: { connect: { id: userId } } },
+      });
     } catch (error) {
       handlePrismaError(error);
     }

--- a/src/services/places.service.ts
+++ b/src/services/places.service.ts
@@ -19,23 +19,27 @@ export const getPlaceById = async (placeId: string) => {
 };
 
 export const createPlace = async (
+  userId: string,
   data: Prisma.PlaceCreateInput,
   fileBuffer?: Buffer,
 ) => {
   let imageUrl: string | null = null;
   let uploadedPublicId: string | null = null; //track cloudinary public id
-  if (fileBuffer) {
-    const uploaded = await uploadOnCloudinary(fileBuffer);
-    imageUrl = uploaded.secure_url;
-    uploadedPublicId = uploaded.public_id;
-  }
 
   try {
-    const newPlace = await placesRepository.create({
-      ...data,
-      image_secure_url: imageUrl, // Store the secure URL of the uploaded image
-      image_public_id: uploadedPublicId, // Store the public ID for future reference
-    });
+    if (fileBuffer) {
+      const uploaded = await uploadOnCloudinary(fileBuffer);
+      imageUrl = uploaded.secure_url;
+      uploadedPublicId = uploaded.public_id;
+    }
+    const newPlace = await placesRepository.create(
+      {
+        ...data,
+        image_secure_url: imageUrl, // Store the secure URL of the uploaded image
+        image_public_id: uploadedPublicId, // Store the public ID for future reference
+      },
+      userId,
+    );
     return newPlace;
   } catch (error) {
     if (uploadedPublicId) {
@@ -45,6 +49,7 @@ export const createPlace = async (
         );
       });
     }
+    throw error;
   }
 };
 
@@ -69,13 +74,21 @@ export const updatePlace = async (
   let imageUrl: string | null = null;
   let uploadedPublicId: string | null = null; //track cloudinary public id
 
-  if (fileBuffer) {
-    const uploaded = await uploadOnCloudinary(fileBuffer);
-    imageUrl = uploaded.secure_url;
-    uploadedPublicId = uploaded.public_id;
-  }
-
   try {
+    if (fileBuffer) {
+      const uploaded = await uploadOnCloudinary(fileBuffer);
+      imageUrl = uploaded.secure_url;
+      uploadedPublicId = uploaded.public_id;
+    }
+
+    //if a new image is uploaded, delete the old one from Cloudinary
+    if (place.image_public_id && uploadedPublicId) {
+      await deleteFromCloudinary(place.image_public_id).catch(() => {
+        console.error(
+          `Failed to delete old image from Cloudinary with public ID: ${place.image_public_id}`,
+        );
+      });
+    }
     const updatedPlace = await placesRepository.update(placeId, {
       ...data,
       image_secure_url: imageUrl || place.image_secure_url,


### PR DESCRIPTION
This pull request refactors the place creation and update logic to improve how user associations and image uploads are handled. The main changes include restructuring the `createPlace` service and repository methods to explicitly pass the `userId` for associating a creator, and improving image management during updates.

**Refactoring place creation for user association:**

* The `createPlace` service and controller methods have been updated to accept and pass the `userId` explicitly, ensuring that the new place is correctly associated with its creator in the database. (`src/controllers/places.controller.ts` 
* The `PlacesRepository.create` method now takes the `userId` separately and connects the new place to the user using Prisma's `connect` syntax, rather than expecting the full relation in the input data. 
**Image upload and cleanup improvements:**

* The image upload logic in both `createPlace` and `updatePlace` now ensures that, if a new image is uploaded, the old image is deleted from Cloudinary to prevent orphaned files and manage storage efficiently. 
* Error handling has been improved in `createPlace` to ensure that if an error occurs after uploading an image, the uploaded image is cleaned up from Cloudinary. 